### PR TITLE
Fix for issue #17 throwing an error

### DIFF
--- a/bootstrap/dist/bikram-sambat-bs.js
+++ b/bootstrap/dist/bikram-sambat-bs.js
@@ -1,173 +1,30 @@
-(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
-"use strict";
-module.exports = {
-	to_euro: require('./to_euro'),
-	to_int: require('./to_int'),
-	to_non_euro: require('./to_non_euro')
-};
-
-},{"./to_euro":2,"./to_int":3,"./to_non_euro":4}],2:[function(require,module,exports){
-'use strict';
-
-function replacer(c) {
-	c = c.charCodeAt(0);
-	if(c < 1642) return c - 1632; // western arabic
-	if(c < 1786) return c - 1776; // perso-arabic
-	return c - 2406; // devanagari
-}
-
-module.exports = function(original) {
-	return original && original.toString().replace(/[٠-٩۰-۹०-९]/g, replacer);
-};
-
-},{}],3:[function(require,module,exports){
-var to_euro = require('./to_euro');
-
-module.exports = function(s) {
-	return Number.parseInt(to_euro(s));
-};
-
-},{"./to_euro":2}],4:[function(require,module,exports){
-'use strict';
-
-function from(base) {
-	function replacer(c) { return String.fromCharCode(Number(c) + base); }
-	return function(original) {
-		return original && original.toString().replace(/[0-9]/g, replacer);
-	};
-}
-
-module.exports = {
-	devanagari: from(2406),
-	eastern_arabic: from(1632),
-	perso_arabic: from(1776)
-};
-
-},{}],5:[function(require,module,exports){
-var bs = require('bikram-sambat');
-var eurodig = require('eurodigit');
-var from_dev = eurodig.to_int;
-var to_dev = eurodig.to_non_euro.devanagari;
-
-
-//> JQUERY SETUP
-
-function initListeners($parent, dateInputSelecter) {
-  if(arguments.length !== 2) throw new Error();
-
-  $parent.find('.devanagari-number-input')
-    // Because we change the content of the input field, we must be careful to
-    // preserve the caret position from before the change.
-    .on('input', function() {
-      var $this = $(this);
-      var selectionStart = this.selectionStart;
-      $this.val(to_dev($this.val()));
-      this.selectionStart = this.selectionEnd = selectionStart;
-    })
-    .on('change blur', function() {
-      var $this = $(this);
-      var $inputGroup = $this.parents('.bikram-sambat-input-group');
-      updateBackingDateInput($inputGroup, dateInputSelecter);
-    })
-    ;
-
-  $parent.find('.bikram-sambat-input-group .dropdown-menu li a')
-    .on('click', function() {
-      var $this = $(this);
-      var $inputGroup = $this.parents('.bikram-sambat-input-group');
-      setVal($inputGroup, 'month', 1+$this.parent('li').index());
-      $this.parents('.input-group-btn').find('.dropdown-toggle').html($this.text() + ' <span class="caret"></span>');
-
-      updateBackingDateInput($inputGroup, dateInputSelecter);
-    });
-}
-
-
-//> HELPER FUNCTIONS
-
-function fieldValue($parent, name) {
-  return from_dev($parent.find('[name='+name+']').val());
-}
-function setVal($parent, name, val) {
-  $parent.find('[name='+name+']').val(to_dev(val));
-}
-function setDropdown($parent, name, val) {
-  var $input = $parent.find('[name='+name+']')
-  $input.parents('.bikram-sambat-input-group')
-    .find('.dropdown-menu li a')
-    .eq(val - 1)
-    .click();
-}
-function updateBackingDateInput($inputGroup, dateInputSelecter) {
-  var greg = getDate_greg_text($inputGroup);
-  if(greg) $(dateInputSelecter).val(greg);
-}
-
-//> EXPORTED FUNCTIONS
-
-module.exports = window.bikram_sambat_bootstrap = {
-  getDate_greg: function($inputGroup) {
-    var year = fieldValue($inputGroup, 'year');
-    var month = fieldValue($inputGroup, 'month');
-    var day = fieldValue($inputGroup, 'day');
-    try {
-      return bs.toGreg(year, month, day);
-    } catch(e) {
-      return null;
-    }
-  },
-  getDate_greg_text: getDate_greg_text,
-  setDate_greg_text: function($inputGroup, dateInputSelecter, gregDateString) {
-    var bik = bs.toBik(gregDateString);
-
-    setVal($inputGroup, 'year', bik.year);
-    setVal($inputGroup, 'day', bik.day);
-    setDropdown($inputGroup, 'month', bik.month);
-  },
-  initListeners: initListeners,
-};
-
-function getDate_greg_text($inputGroup) {
-  var year = fieldValue($inputGroup, 'year');
-  var month = fieldValue($inputGroup, 'month');
-  var day = fieldValue($inputGroup, 'day');
-  try {
-    return bs.toGreg_text(year, month, day);
-  } catch(e) {
-    return null;
-  }
-}
-
-},{"bikram-sambat":7,"eurodigit":1}],6:[function(require,module,exports){
-arguments[4][4][0].apply(exports,arguments)
-},{"dup":4}],7:[function(require,module,exports){
+(function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
 var toDevanagari = require('eurodigit/src/to_non_euro').devanagari;
-
 var MS_PER_DAY = 86400000;
+var MONTH_NAMES = ['बैशाख', 'जेठ', 'असार', 'साउन', 'भदौ', 'असोज', 'कार्तिक', 'मंसिर', 'पौष', 'माघ', 'फाल्गुन', 'चैत'];
 
-// We have defined our own Epoch for Bikram Sambat: 1-1-2007 BS / 13-4-1950 AD
-var BS_EPOCH_TS = -622359900000; // = Date.parse('1950-4-13')
-var BS_YEAR_ZERO = 2007;
+// ------ TO UPDATE THESE HARDCODED VALUES USE /scripts/encode-days-in-month.js
+// We have defined our own Epoch for Bikram Sambat: 1970-1-1 BS or 1913-4-13 AD
+var BS_EPOCH_TS = -1789990200000; // = Date.parse('1913-4-13')
+var BS_YEAR_ZERO = 1970;
+var ENCODED_MONTH_LENGTHS = [
+  5315258,5314490,9459438,8673005,5315258,5315066,9459438,8673005,5315258,5314298,9459438,5327594,5315258,5314298,9459438,5327594,5315258,5314286,9459438,5315306,5315258,5314286,8673006,5315306,5315258,5265134,8673006,5315258,5315258,9459438,8673005,5315258,5314298,9459438,8673005,5315258,5314298,9459438,8473322,5315258,5314298,9459438,5327594,5315258,5314298,9459438,5327594,5315258,5314286,8673006,5315306,5315258,5265134,8673006,5315306,5315258,9459438,8673005,5315258,5314490,9459438,8673005,5315258,5314298,9459438,8473325,5315258,5314298,9459438,5327594,5315258,5314298,9459438,5327594,5315258,5314286,9459438,5315306,5315258,5265134,8673006,5315306,5315258,5265134,8673006,5315258,5314490,9459438,8673005,5315258,5314298,9459438,8669933,5315258,5314298,9459438,8473322,5315258,5314298,9459438,5327594,5315258,5314286,9459438,5315306,5315258,5265134,8673006,5315306,5315258,5265134,5527290,5527277,5527226,5527226,5528046,5527277,5528250,5528057,5527277,5527277
+];
 
-// TODO this would be stored more efficiently converted to a string using
+// TODO ENCODED_MONTH_LENGTHS would be stored more efficiently converted to a string using
 // String.fromCharCode.apply(String, ENCODED_MONTH_LENGTHS), and extracted using
 // ENC_MTH.charCodeAt(...).  However, JS seems to do something weird with the
 // top bits.
-var ENCODED_MONTH_LENGTHS = [
-      8673005,5315258,5314298,9459438,8673005,5315258,5314298,9459438,8473322,5315258,5314298,9459438,5327594,5315258,5314298,9459438,5327594,5315258,5314286,8673006,5315306,5315258,5265134,8673006,5315306,5315258,9459438,8673005,5315258,5314490,9459438,8673005,5315258,5314298,9459438,8473325,5315258,5314298,9459438,5327594,5315258,5314298,9459438,5327594,5315258,5314286,9459438,5315306,5315258,5265134,8673006,5315306,5315258,5265134,8673006,5315258,5314490,9459438,8673005,5315258,5314298,9459438,8669933,5315258,5314298,9459438,8473322,5315258,5314298,9459438,5327594,5315258,5314286,9459438,5315306,5315258,5265134,8673006,5315306,5315258,5265134,5527290,5527277,5527226,5527226,5528046,5527277,5528250,5528057,5527277,5527277
-    ],
-    MONTH_NAMES = ['बैशाख', 'जेठ', 'असार', 'साउन', 'भदौ', 'असोज', 'कार्तिक', 'मंसिर', 'पौष', 'माघ', 'फाल्गुन', 'चैत'];
 
 /**
  * Magic numbers:
- *   2000 <- the first year (BS) encoded in ENCODED_MONTH_LENGTHS
+ *   BS_YEAR_ZERO <- the first year (BS) encoded in ENCODED_MONTH_LENGTHS
  *   month #5 <- this is the only month which has a day variation of more than 1
  *   & 3 <- this is a 2 bit mask, i.e. 0...011
  */
 function daysInMonth(year, month) {
-  // TODO why does this accept 0?
-  if(month < 0 || month > 12) throw new Error('Invalid month value ' + month);
-  var delta = ENCODED_MONTH_LENGTHS[year - 2000];
+  if(month < 1 || month > 12) throw new Error('Invalid month value ' + month);
+  var delta = ENCODED_MONTH_LENGTHS[year - BS_YEAR_ZERO];
   if(typeof delta === 'undefined') throw new Error('No data for year: ' + year + ' BS');
   return 29 + ((delta >>>
       (((month-1) << 1))) & 3);
@@ -212,15 +69,16 @@ function toGreg(year, month, day) {
   if(year < BS_YEAR_ZERO) throw new Error('Invalid year value ' + year);
   if(day < 1 || day > daysInMonth(year, month)) throw new Error('Invalid day value', day);
 
-  var timestamp = BS_EPOCH_TS;
-  while(year >= BS_YEAR_ZERO) {
-    while(month >= 1) {
-      while(--day >= 0) {
-        timestamp += MS_PER_DAY;
-      }
-      day = daysInMonth(year, --month);
+  var timestamp = BS_EPOCH_TS + (MS_PER_DAY * day);
+  month--;
+
+  while (year >= BS_YEAR_ZERO) {
+    while (month > 0) {
+      timestamp += (MS_PER_DAY * daysInMonth(year, month));
+      month--;
     }
-    day = daysInMonth(--year, month = 12);
+    month = 12;
+    year--;
   }
 
   var d = new Date(timestamp);
@@ -246,4 +104,145 @@ module.exports = {
   toGreg_text: toGreg_text
 };
 
-},{"eurodigit/src/to_non_euro":6}]},{},[5]);
+},{"eurodigit/src/to_non_euro":5}],2:[function(require,module,exports){
+"use strict";
+module.exports = {
+	to_euro: require('./to_euro'),
+	to_int: require('./to_int'),
+	to_non_euro: require('./to_non_euro')
+};
+
+},{"./to_euro":3,"./to_int":4,"./to_non_euro":5}],3:[function(require,module,exports){
+'use strict';
+
+function replacer(c) {
+	c = c.charCodeAt(0);
+	if(c < 1642) return c - 1632; // western arabic
+	if(c < 1786) return c - 1776; // perso-arabic
+	return c - 2406; // devanagari
+}
+
+module.exports = function(original) {
+	return original && original.toString().replace(/[٠-٩۰-۹०-९]/g, replacer);
+};
+
+},{}],4:[function(require,module,exports){
+var to_euro = require('./to_euro');
+
+module.exports = function(s) {
+	return parseInt(to_euro(s), 10);
+};
+
+},{"./to_euro":3}],5:[function(require,module,exports){
+'use strict';
+
+function from(base) {
+	function replacer(c) { return String.fromCharCode(Number(c) + base); }
+	return function(original) {
+		return original && original.toString().replace(/[0-9]/g, replacer);
+	};
+}
+
+module.exports = {
+	devanagari: from(2406),
+	eastern_arabic: from(1632),
+	perso_arabic: from(1776)
+};
+
+},{}],6:[function(require,module,exports){
+var bs = require('bikram-sambat');
+var eurodig = require('eurodigit');
+var from_dev = eurodig.to_int;
+var to_dev = eurodig.to_non_euro.devanagari;
+
+
+//> JQUERY SETUP
+
+function initListeners($parent, dateInputSelecter) {
+  if(arguments.length !== 2) throw new Error();
+
+  $parent.find('.devanagari-number-input')
+    // Because we change the content of the input field, we must be careful to
+    // preserve the caret position from before the change.
+    .on('input', function() {
+      var $this = $(this);
+      var selectionStart = this.selectionStart;
+      $this.val(to_dev($this.val()));
+      this.selectionStart = this.selectionEnd = selectionStart;
+    })
+    .on('change blur', function() {
+      var $this = $(this);
+      var $inputGroup = $this.parents('.bikram-sambat-input-group');
+      updateConvertedDate($inputGroup, dateInputSelecter);
+    })
+    ;
+
+  $parent.find('.bikram-sambat-input-group .dropdown-menu li a')
+    .on('click', function() {
+      var $this = $(this);
+      var $inputGroup = $this.parents('.bikram-sambat-input-group');
+      setVal($inputGroup, 'month', 1+$this.parent('li').index());
+      $this.parents('.input-group-btn').find('.dropdown-toggle').html($this.text() + ' <span class="caret"></span>');
+
+      updateConvertedDate($inputGroup, dateInputSelecter);
+    });
+}
+
+
+//> HELPER FUNCTIONS
+
+function fieldValue($parent, name) {
+  return from_dev($parent.find('[name='+name+']').val());
+}
+function setVal($parent, name, val) {
+  $parent.find('[name='+name+']').val(to_dev(val));
+}
+function setDropdown($parent, name, val) {
+  var $input = $parent.find('[name='+name+']');
+  $input.parents('.bikram-sambat-input-group')
+    .find('.dropdown-menu li a')
+    .eq(val - 1)
+    .click();
+}
+
+function updateConvertedDate($inputGroup, dateInputSelecter) {
+  var greg = getDate_greg_text($inputGroup);
+  $(dateInputSelecter).val(greg).trigger('change');
+}
+
+//> EXPORTED FUNCTIONS
+
+module.exports = window.bikram_sambat_bootstrap = {
+  getDate_greg: function($inputGroup) {
+    var year = fieldValue($inputGroup, 'year');
+    var month = fieldValue($inputGroup, 'month');
+    var day = fieldValue($inputGroup, 'day');
+    try {
+      return bs.toGreg(year, month, day);
+    } catch(e) {
+      return null;
+    }
+  },
+  getDate_greg_text: getDate_greg_text,
+  setDate_greg_text: function($inputGroup, dateInputSelecter, gregDateString) {
+    var bik = bs.toBik(gregDateString);
+
+    setVal($inputGroup, 'year', bik.year);
+    setVal($inputGroup, 'day', bik.day);
+    setDropdown($inputGroup, 'month', bik.month);
+  },
+  initListeners: initListeners,
+};
+
+function getDate_greg_text($inputGroup) {
+  var year = fieldValue($inputGroup, 'year');
+  var month = fieldValue($inputGroup, 'month');
+  var day = fieldValue($inputGroup, 'day');
+  try {
+    return bs.toGreg_text(year, month, day);
+  } catch(e) {
+    return null;
+  }
+}
+
+},{"bikram-sambat":1,"eurodigit":2}]},{},[6]);

--- a/bootstrap/package-lock.json
+++ b/bootstrap/package-lock.json
@@ -118,9 +118,9 @@
       "dev": true
     },
     "bikram-sambat": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/bikram-sambat/-/bikram-sambat-1.6.0.tgz",
-      "integrity": "sha512-jYHI/6obamcWpf8+vfbidSz7L3AUHAnHU/P9UIH7PdduECxnJ8JCKxdO7UpPTTr/1l4XMj0+uQ/AAPz5C7VM8Q==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/bikram-sambat/-/bikram-sambat-1.7.0.tgz",
+      "integrity": "sha512-wcFkKw+wruQhlTEy5km5t38mVYIeO1t9fjGGnfXoHfDxh0VLDouKjHVhlfvQbZIT5CNoWMymA2v4WEWMcL+Rvw==",
       "requires": {
         "eurodigit": "^3.1.3"
       }

--- a/bootstrap/package-lock.json
+++ b/bootstrap/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bikram-sambat-bootstrap",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/bootstrap/package.json
+++ b/bootstrap/package.json
@@ -24,7 +24,7 @@
     "jshint": "^2.9.5"
   },
   "dependencies": {
-    "bikram-sambat": "^1.6.0",
+    "bikram-sambat": "^1.7.0",
     "eurodigit": "^3.1.1"
   }
 }

--- a/bootstrap/package.json
+++ b/bootstrap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bikram-sambat-bootstrap",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "bikram sambat datepicker for bootstrap",
   "main": "src/bikram-sambat-bootstrap.js",
   "scripts": {

--- a/bootstrap/src/bikram-sambat-bootstrap.js
+++ b/bootstrap/src/bikram-sambat-bootstrap.js
@@ -21,7 +21,7 @@ function initListeners($parent, dateInputSelecter) {
     .on('change blur', function() {
       var $this = $(this);
       var $inputGroup = $this.parents('.bikram-sambat-input-group');
-      updateBackingDateInput($inputGroup, dateInputSelecter);
+      updateConvertedDate($inputGroup, dateInputSelecter);
     })
     ;
 
@@ -32,7 +32,7 @@ function initListeners($parent, dateInputSelecter) {
       setVal($inputGroup, 'month', 1+$this.parent('li').index());
       $this.parents('.input-group-btn').find('.dropdown-toggle').html($this.text() + ' <span class="caret"></span>');
 
-      updateBackingDateInput($inputGroup, dateInputSelecter);
+      updateConvertedDate($inputGroup, dateInputSelecter);
     });
 }
 
@@ -52,9 +52,10 @@ function setDropdown($parent, name, val) {
     .eq(val - 1)
     .click();
 }
-function updateBackingDateInput($inputGroup, dateInputSelecter) {
+
+function updateConvertedDate($inputGroup, dateInputSelecter) {
   var greg = getDate_greg_text($inputGroup);
-  if(greg) $(dateInputSelecter).val(greg).trigger('change');
+  $(dateInputSelecter).val(greg).trigger('change');
 }
 
 //> EXPORTED FUNCTIONS


### PR DESCRIPTION
Fix for issue #17: 

Currently, a bootstrap sets only a valid BS date and if any invalid date is input, it'll store the previously set date and user won'd know that their input was invalid. This fix will enable bootstrap to pass null if invalid date is inputed by user such that other tools using this component know and handle it correctly. 