### PR TITLE
chore(#31): bump JS version to 1.8.1

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bikram-sambat",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bikram-sambat",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "license": "Apache-2.0",
       "dependencies": {
         "eurodigit": "^3.1.3"

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bikram-sambat",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "JS utilities for converting between the Nepali Bikram Sambat (Vikram Samvat) and Gregorian (standard European) calendars.",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
Bumps the JS library version `1.8.0 → 1.8.1` to release the 2083 BS days-in-month fix (#31, merged in #32).

Once merged, tag `js-1.8.1` to publish `bikram-sambat@1.8.1` to npm. The bootstrap bump (its dependency on `bikram-sambat@^1.8.1`) will follow in a separate PR, since its `npm ci` can only resolve the new version after it is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)