### PR TITLE
chore(#31): bump bootstrap to 1.8.1

### DIFF
--- a/bootstrap/package-lock.json
+++ b/bootstrap/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "bikram-sambat-bootstrap",
-  "version": "1.6.0",
+  "version": "1.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bikram-sambat-bootstrap",
-      "version": "1.6.0",
+      "version": "1.8.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "bikram-sambat": "^1.8.0",
+        "bikram-sambat": "^1.8.1",
         "eurodigit": "^3.1.1"
       },
       "devDependencies": {
@@ -133,9 +133,9 @@
       "dev": true
     },
     "node_modules/bikram-sambat": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/bikram-sambat/-/bikram-sambat-1.8.0.tgz",
-      "integrity": "sha512-W31TkhvV5C1yiWEhF7XnVJOHPVK6ph1INVS8CNSWrlF5JPAnH6T4xU5S49LVrmZgR15LM9RH0LixtovXT1prKw==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/bikram-sambat/-/bikram-sambat-1.8.1.tgz",
+      "integrity": "sha512-2leyyRBTUktjY07ZItl0UKPj5AhQ+Qay8+DMU52N/FV6ouPEunsmNgNZhH1KlcGZc5oBrOMgzAkG9/Drdmiidg==",
       "license": "Apache-2.0",
       "dependencies": {
         "eurodigit": "^3.1.3"

--- a/bootstrap/package.json
+++ b/bootstrap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bikram-sambat-bootstrap",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "bikram sambat datepicker for bootstrap",
   "main": "src/bikram-sambat-bootstrap.js",
   "scripts": {
@@ -24,7 +24,7 @@
     "jshint": "^2.9.5"
   },
   "dependencies": {
-    "bikram-sambat": "^1.8.0",
+    "bikram-sambat": "^1.8.1",
     "eurodigit": "^3.1.1"
   }
 }


### PR DESCRIPTION
Bumps `bikram-sambat-bootstrap` `1.8.0 → 1.8.1` and its `bikram-sambat` dependency `^1.8.0 → ^1.8.1`, picking up the 2083 BS days-in-month fix (#31).

The lockfile now resolves `bikram-sambat@1.8.1` from npm (published from #33). Verified locally with a clean `npm ci` + `npm test`.

Once merged, tag `bootstrap-1.8.1` to release.

> [!NOTE]
> The committed `bootstrap/dist/bikram-sambat-bs.js` bundle is left as-is — it has not been rebuilt since the ~1.6 era and the previous 1.8.0 bump (#30) also did not regenerate it, so it's out of scope here. It's a demo artifact (consumers use the npm `bikram-sambat` package, not this bundle), but worth rebuilding separately if anyone relies on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)